### PR TITLE
chore: maintenance updates of dependencies to become compatible with Axum 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "problem_details"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Markus Gasser <markus.gasser@mailbox.org>"]
 edition = "2021"
 description = "RFC 9457 / RFC 7807 problem details for HTTP APIs."
@@ -16,21 +16,21 @@ all-features = true
 maintenance = { status = "experimental" }
 
 [dependencies]
-http = "1.0"
+http = "1.2"
 
 # Optional Dependencies
-axum = { version = "0.7", default-features = false, features = ["json"], optional = true }
-http-serde = { version = "2.0", default-features = false, optional = true }
+axum = { version = "0.8", default-features = false, features = ["json"], optional = true }
+http-serde = { version = "2.1", default-features = false, optional = true }
 poem = { version = "2.0", default-features = false, optional = true }
-quick-xml = { version = "0.31", default-features = false, features = ["serialize"], optional = true }
+quick-xml = { version = "0.37", default-features = false, features = ["serialize"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-axum = "0.7"
+axum = "0.8"
 poem = "2.0"
 serde_json = "1.0"
-tokio = { version = "1.35", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.42", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["serde", "json"]

--- a/src/problem_details/json.rs
+++ b/src/problem_details/json.rs
@@ -29,7 +29,7 @@ where
 {
     /// Write this problem details to an JSON string suitable for a response body.
     pub fn to_body_string(&self) -> Result<String, JsonError> {
-        serde_json::to_string(&self.0).map_err(|e| JsonError::Serialization(e))
+        serde_json::to_string(&self.0).map_err(JsonError::Serialization)
     }
 }
 


### PR DESCRIPTION
## Description

This PR introduces the following changes:

- resolved clippy lint about redundant closure
- updated miscellaneous dependencies **except** `poem` (which I know too little about)
- updated `axum` to `v0.8.0` (breaking) -> bumped this crate's version

I have tested these changes locally and they work for `axum v0.8.0` just fine.

## Type of change

- Breaking Change
- Update

---

CC @frenetisch-applaudierend 