### PR TITLE
Add utoipa support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ quick-xml = { version = "0.37", default-features = false, features = ["serialize
 serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 actix-web = { version = "4.9", default-features = false, optional = true }
+utoipa = { version = "5.4", default-features = false, features = ["macros", "url"], optional = true }
 
 [dev-dependencies]
 axum = "0.8"
@@ -30,6 +31,7 @@ poem = "3.1"
 actix-web = "4.9"
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["macros", "rt-multi-thread"] }
+utoipa-axum = "0.2"
 
 [features]
 default = ["serde", "json"]
@@ -39,6 +41,7 @@ xml = ["serde", "dep:quick-xml"]
 axum = ["dep:axum"]
 poem = ["dep:poem"]
 actix = ["dep:actix-web"]
+utoipa = ["dep:utoipa"]
 
 [[example]]
 name = "axum"
@@ -51,3 +54,7 @@ required-features = ["poem", "json", "xml"]
 [[example]]
 name = "actix"
 required-features = ["actix", "json", "xml"]
+
+[[example]]
+name = "axum-utoipa"
+required-features = ["axum", "json", "xml", "utoipa"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ If you need dynamic extensions, you can use a `HashMap` as extensions object.
              web framework, enabling to return `ProblemDetails` as responses and errors.
 - **actix**: Enables integration with the [`actix-web`](https://crates.io/crates/actix-web) web framework, allowing to
              return `ProblemDetails` as errors.
+- **utoipa**: Enables integration with the [`utoipa`](https://crates.io/crates/utoipa) OpenAPI schema generator, allowing to
+             use `ProblemDetails` as response type.
 
 ## Caveats
 

--- a/examples/axum-utoipa.rs
+++ b/examples/axum-utoipa.rs
@@ -1,0 +1,79 @@
+use axum::{routing::get, Json};
+use http::StatusCode;
+use problem_details::{JsonProblemDetails, ProblemDetails, XmlProblemDetails};
+use tokio::net::TcpListener;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+#[tokio::main]
+async fn main() {
+    // build our application with a single route
+    let (app, api) = OpenApiRouter::new()
+        .routes(routes!(default))
+        .routes(routes!(json))
+        .routes(routes!(xml))
+        .split_for_parts();
+
+    let app = app.route("/openapi.json", get(move || async move { Json(api) }));
+
+    // run it with hyper on localhost:3000
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+/// ProblemDetails in default format
+#[utoipa::path(
+    get,
+    path = "/",
+    responses(
+        (status = OK, body = String, description = "Success"),
+        (status = IM_A_TEAPOT, body = ProblemDetails, description = "I'm a teapot!"),
+    ),
+)]
+async fn default() -> Result<&'static str, ProblemDetails> {
+    // always return an error with a problem description
+    Err(ProblemDetails::from_status_code(StatusCode::IM_A_TEAPOT).with_detail("short and stout"))
+}
+
+/// ProblemDetails in JSON format
+#[utoipa::path(
+    get,
+    path = "/json",
+    responses(
+        (status = OK, body = String, description = "Success"),
+        (
+            status = IM_A_TEAPOT,
+            body = ProblemDetails,
+            description = "I'm a teapot!",
+            content_type = JsonProblemDetails::<()>::CONTENT_TYPE,
+        ),
+    ),
+)]
+async fn json() -> Result<&'static str, JsonProblemDetails> {
+    // always return an error with a problem description
+    Err(ProblemDetails::from_status_code(StatusCode::IM_A_TEAPOT)
+        .with_detail("short and stout")
+        .into())
+}
+
+/// ProblemDetails in XML format
+#[utoipa::path(
+    get,
+    path = "/xml",
+    responses(
+        (status = OK, body = String, description = "Success"),
+        (
+            status = IM_A_TEAPOT,
+            body = ProblemDetails,
+            description = "I'm a teapot!",
+            content_type = XmlProblemDetails::<()>::CONTENT_TYPE,
+        ),
+    ),
+)]
+async fn xml() -> Result<&'static str, XmlProblemDetails> {
+    // always return an error with a problem description
+    // NOTE: some browsers don't like the content type application/problem+xml and report an error
+    //       like "invalid content" or similar. Use curl instead to see the response in this case.
+    Err(ProblemDetails::from_status_code(StatusCode::IM_A_TEAPOT)
+        .with_detail("short and stout")
+        .into())
+}

--- a/src/problem_details.rs
+++ b/src/problem_details.rs
@@ -167,7 +167,7 @@ pub struct ProblemDetails<Ext = ()> {
     ///
     /// See [https://www.rfc-editor.org/rfc/rfc9457.html#name-extension-members]() for more information.
     #[cfg_attr(feature = "serde", serde(flatten))]
-    #[schema(inline)]
+    #[cfg_attr(feature = "utoipa", schema(inline))]
     pub extensions: Ext,
 }
 

--- a/src/problem_details.rs
+++ b/src/problem_details.rs
@@ -114,12 +114,18 @@ mod tests;
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "utoipa",
+    schema(description = "RFC 9457 / RFC 7807 problem details")
+)]
 pub struct ProblemDetails<Ext = ()> {
     /// An optional uri describing the problem type.
     ///
     /// See [https://www.rfc-editor.org/rfc/rfc9457.html#name-type]() for more information.
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "utoipa", schema(value_type = String, format = Uri))]
     pub r#type: Option<ProblemType>,
 
     /// An optional status code for this problem.
@@ -128,6 +134,7 @@ pub struct ProblemDetails<Ext = ()> {
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::status::opt"))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "utoipa", schema(value_type = u16))]
     pub status: Option<StatusCode>,
 
     /// An optional human-readable title for this problem.
@@ -150,6 +157,7 @@ pub struct ProblemDetails<Ext = ()> {
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::uri::opt"))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(feature = "utoipa", schema(value_type = String, format = Uri))]
     pub instance: Option<Uri>,
 
     /// An object containing extensions to this problem details object.
@@ -159,6 +167,7 @@ pub struct ProblemDetails<Ext = ()> {
     ///
     /// See [https://www.rfc-editor.org/rfc/rfc9457.html#name-extension-members]() for more information.
     #[cfg_attr(feature = "serde", serde(flatten))]
+    #[schema(inline)]
     pub extensions: Ext,
 }
 


### PR DESCRIPTION
Adds an `utoipa` feature that can be used to derive an OpenAPI schema for ProblemDetails using the optional `utoipa` dependency.

Adds an `axum-utoipa` example for usage with `axum` framework.